### PR TITLE
Fix missing carousel script and remove duplicate slideshow code

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,37 +132,6 @@
   </footer>
 
   <script src="slideshow.js"></script>
-
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const slides = document.querySelectorAll('.hero.slideshow .slide');
-      const next = document.querySelector('.slideshow-nav .next');
-      const prev = document.querySelector('.slideshow-nav .prev');
-      let current = 0;
-
-      function showSlide(index) {
-        slides.forEach((slide, i) => {
-          slide.classList.toggle('active', i === index);
-        });
-      }
-
-      function nextSlide() {
-        current = (current + 1) % slides.length;
-        showSlide(current);
-      }
-
-      function prevSlide() {
-        current = (current - 1 + slides.length) % slides.length;
-        showSlide(current);
-      }
-
-      next.addEventListener('click', nextSlide);
-      prev.addEventListener('click', prevSlide);
-
-      showSlide(current);
-      setInterval(nextSlide, 5000);
-    });
-  </script>
-
+  <script src="carousel.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove duplicate inline slideshow script in `index.html`
- include the missing `carousel.js` script so the product carousel works

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684042faa084832993136a293a597a6b