### PR TITLE
Fix Eurostile Candy font filename

### DIFF
--- a/style.css
+++ b/style.css
@@ -49,8 +49,8 @@
 
 @font-face {
   font-family: 'Eurostile Candy';
-  src: url('fonts/eurostilecandylntpro-regular-webfont.woff2') format('woff2'),
-       url('fonts/eurostilecandylntpro-regular-webfont.woff')  format('woff'),
+  src: url('fonts/eurostilecandyltpro-regular-webfont.woff2') format('woff2'),
+       url('fonts/eurostilecandyltpro-regular-webfont.woff')  format('woff'),
        url('fonts/EurostileCandyLTPro-Regular.otf')           format('opentype');
   font-weight: 400;
   font-style: normal;


### PR DESCRIPTION
## Summary
- correct Eurostile Candy font file paths in `style.css`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684044b9fbc48329874c407a9c9ba1df