### PR TITLE
Add Produkte page

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <header>
     <img src="images/TORCMAN_Logo_90.png" alt="Torcman Logo" class="logo">
     <nav>
-      <a href="#produkte">Produkte</a>
+      <a href="produkte.html">Produkte</a>
       <a href="#ueber-uns">Über uns</a>
       <a href="#kontakt">Kontakt</a>
     </nav>

--- a/produkte.html
+++ b/produkte.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Torcman – Produkte</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <img src="images/TORCMAN_Logo_90.png" alt="Torcman Logo" class="logo">
+    <nav>
+      <a href="index.html#produkte">Produkte</a>
+      <a href="index.html#ueber-uns">Über uns</a>
+      <a href="index.html#kontakt">Kontakt</a>
+    </nav>
+  </header>
+
+  <main>
+    <h1 class="page-title">Produkte</h1>
+    <section class="product-grid">
+      <div class="product-card">
+        <img src="images/antriebe.png" alt="Antriebe">
+        <h3>Antriebe</h3>
+        <p>Leistungsstarke Außenläufer-Motoren für höchste Effizienz.</p>
+        <a href="#" class="btn">Mehr erfahren</a>
+      </div>
+      <div class="product-card">
+        <img src="images/fahrwerke.png" alt="Fahrwerke">
+        <h3>Fahrwerke</h3>
+        <p>Präzise gefertigte Einziehfahrwerke für elegante Starts.</p>
+        <a href="#" class="btn">Mehr erfahren</a>
+      </div>
+      <div class="product-card">
+        <img src="images/fes-ex-system.png" alt="FES-Ex System">
+        <h3>FES-Ex System</h3>
+        <p>Innovative Front-Elektro-Startlösungen für Segelflugmodelle.</p>
+        <a href="#" class="btn">Mehr erfahren</a>
+      </div>
+      <div class="product-card">
+        <img src="images/zubehoer.png" alt="Zubehör">
+        <h3>Zubehör</h3>
+        <p>Passgenaues Zubehör – von Luftschrauben bis Spezialkabeln.</p>
+        <a href="#" class="btn">Mehr erfahren</a>
+      </div>
+      <div class="product-card">
+        <img src="images/entwicklung.png" alt="Entwicklung">
+        <h3>Entwicklung</h3>
+        <p>Maßgeschneiderte Entwicklungsdienstleistungen für Antriebssysteme.</p>
+        <a href="#" class="btn">Mehr erfahren</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    &copy; 2025 Torcman GmbH – Alle Rechte vorbehalten.
+  </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -276,6 +276,36 @@ section h2 {
   }
 }
 
+/* 6a. Produkteseite Raster */
+.product-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin: 4rem auto;
+  max-width: 1000px;
+}
+.product-grid .product-card {
+  width: var(--card-w);
+  flex: 0 0 auto;
+  background: var(--white);
+  border: 1px solid var(--lightgrey);
+  border-radius: 6px;
+  overflow: hidden;
+  text-align: center;
+  transition: transform 0.3s;
+}
+.product-grid .product-card:hover {
+  transform: translateY(-6px);
+}
+
+.page-title {
+  font-family: 'Microgramma', sans-serif;
+  text-align: center;
+  margin: 2rem 0 1rem;
+  font-size: 2rem;
+}
+
 /* 7. Über uns */
 #ueber-uns {
   max-width: 800px;


### PR DESCRIPTION
## Summary
- add a new `produkte.html` page listing the five product categories
- link to the new page from the navigation on the homepage
- style the product grid to fit the existing design

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684047fea17883299830a823deb0826d