### PR TITLE
Add product category pages

### DIFF
--- a/antriebe.html
+++ b/antriebe.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Torcman – Antriebe</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <a href="index.html">
+      <img src="images/TORCMAN_Logo_90.png" alt="Torcman Logo" class="logo">
+    </a>
+    <nav>
+      <a href="produkte.html">Produkte</a>
+      <a href="index.html#ueber-uns">Über uns</a>
+      <a href="index.html#kontakt">Kontakt</a>
+    </nav>
+  </header>
+  <main>
+    <h1 class="page-title">Antriebe</h1>
+    <section class="product-detail">
+      <img src="images/antriebe.png" alt="Antriebe">
+      <p>Leistungsstarke Außenläufer-Motoren für höchste Effizienz und Zuverlässigkeit.</p>
+    </section>
+  </main>
+  <footer>
+    &copy; 2025 Torcman GmbH – Alle Rechte vorbehalten.
+  </footer>
+</body>
+</html>

--- a/entwicklung.html
+++ b/entwicklung.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Torcman – Entwicklung</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <a href="index.html">
+      <img src="images/TORCMAN_Logo_90.png" alt="Torcman Logo" class="logo">
+    </a>
+    <nav>
+      <a href="produkte.html">Produkte</a>
+      <a href="index.html#ueber-uns">Über uns</a>
+      <a href="index.html#kontakt">Kontakt</a>
+    </nav>
+  </header>
+  <main>
+    <h1 class="page-title">Entwicklung</h1>
+    <section class="product-detail">
+      <img src="images/entwicklung.png" alt="Entwicklung">
+      <p>Maßgeschneiderte Entwicklungsdienstleistungen für Antriebssysteme.</p>
+    </section>
+  </main>
+  <footer>
+    &copy; 2025 Torcman GmbH – Alle Rechte vorbehalten.
+  </footer>
+</body>
+</html>

--- a/fahrwerke.html
+++ b/fahrwerke.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Torcman – Fahrwerke</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <a href="index.html">
+      <img src="images/TORCMAN_Logo_90.png" alt="Torcman Logo" class="logo">
+    </a>
+    <nav>
+      <a href="produkte.html">Produkte</a>
+      <a href="index.html#ueber-uns">Über uns</a>
+      <a href="index.html#kontakt">Kontakt</a>
+    </nav>
+  </header>
+  <main>
+    <h1 class="page-title">Fahrwerke</h1>
+    <section class="product-detail">
+      <img src="images/fahrwerke.png" alt="Fahrwerke">
+      <p>Präzise gefertigte Einziehfahrwerke für elegante Starts und Landungen.</p>
+    </section>
+  </main>
+  <footer>
+    &copy; 2025 Torcman GmbH – Alle Rechte vorbehalten.
+  </footer>
+</body>
+</html>

--- a/fes-ex-system.html
+++ b/fes-ex-system.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Torcman – FES-Ex System</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <a href="index.html">
+      <img src="images/TORCMAN_Logo_90.png" alt="Torcman Logo" class="logo">
+    </a>
+    <nav>
+      <a href="produkte.html">Produkte</a>
+      <a href="index.html#ueber-uns">Über uns</a>
+      <a href="index.html#kontakt">Kontakt</a>
+    </nav>
+  </header>
+  <main>
+    <h1 class="page-title">FES-Ex System</h1>
+    <section class="product-detail">
+      <img src="images/fes-ex-system.png" alt="FES-Ex System">
+      <p>Innovative Front-Elektro-Startlösungen für Segelflugmodelle.</p>
+    </section>
+  </main>
+  <footer>
+    &copy; 2025 Torcman GmbH – Alle Rechte vorbehalten.
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -46,31 +46,31 @@
         <img src="images/antriebe.png" alt="Antriebe">
         <h3>Antriebe</h3>
         <p>Leistungsstarke Außenläufer-Motoren für höchste Effizienz.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="antriebe.html" class="btn">Mehr erfahren</a>
       </div>
       <div class="product-card">
         <img src="images/fahrwerke.png" alt="Fahrwerke">
         <h3>Fahrwerke</h3>
         <p>Präzise gefertigte Einziehfahrwerke für elegante Starts.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="fahrwerke.html" class="btn">Mehr erfahren</a>
       </div>
       <div class="product-card">
         <img src="images/fes-ex-system.png" alt="FES-Ex System">
         <h3>FES-Ex System</h3>
         <p>Innovative Front-Elektro-Startlösungen für Segelflugmodelle.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="fes-ex-system.html" class="btn">Mehr erfahren</a>
       </div>
       <div class="product-card">
         <img src="images/zubehoer.png" alt="Zubehör">
         <h3>Zubehör</h3>
         <p>Passgenaues Zubehör – von Luftschrauben bis Spezialkabeln.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="zubehoer.html" class="btn">Mehr erfahren</a>
       </div>
       <div class="product-card">
         <img src="images/entwicklung.png" alt="Entwicklung">
         <h3>Entwicklung</h3>
         <p>Maßgeschneiderte Entwicklungsdienstleistungen für Antriebssysteme.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="entwicklung.html" class="btn">Mehr erfahren</a>
       </div>
   
       <!-- 2) Duplikat für den nahtlosen Loop -->
@@ -78,31 +78,31 @@
         <img src="images/antriebe.png" alt="Antriebe">
         <h3>Antriebe</h3>
         <p>Leistungsstarke Außenläufer-Motoren für höchste Effizienz.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="antriebe.html" class="btn">Mehr erfahren</a>
       </div>
       <div class="product-card">
         <img src="images/fahrwerke.png" alt="Fahrwerke">
         <h3>Fahrwerke</h3>
         <p>Präzise gefertigte Einziehfahrwerke für elegante Starts.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="fahrwerke.html" class="btn">Mehr erfahren</a>
       </div>
       <div class="product-card">
         <img src="images/fes-ex-system.png" alt="FES-Ex System">
         <h3>FES-Ex System</h3>
         <p>Innovative Front-Elektro-Startlösungen für Segelflugmodelle.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="fes-ex-system.html" class="btn">Mehr erfahren</a>
       </div>
       <div class="product-card">
         <img src="images/zubehoer.png" alt="Zubehör">
         <h3>Zubehör</h3>
         <p>Passgenaues Zubehör – von Luftschrauben bis Spezialkabeln.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="zubehoer.html" class="btn">Mehr erfahren</a>
       </div>
       <div class="product-card">
         <img src="images/entwicklung.png" alt="Entwicklung">
         <h3>Entwicklung</h3>
         <p>Maßgeschneiderte Entwicklungsdienstleistungen für Antriebssysteme.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="entwicklung.html" class="btn">Mehr erfahren</a>
       </div>
     </div>
   

--- a/produkte.html
+++ b/produkte.html
@@ -25,31 +25,31 @@
         <img src="images/antriebe.png" alt="Antriebe">
         <h3>Antriebe</h3>
         <p>Leistungsstarke Außenläufer-Motoren für höchste Effizienz.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="antriebe.html" class="btn">Mehr erfahren</a>
       </div>
       <div class="product-card">
         <img src="images/fahrwerke.png" alt="Fahrwerke">
         <h3>Fahrwerke</h3>
         <p>Präzise gefertigte Einziehfahrwerke für elegante Starts.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="fahrwerke.html" class="btn">Mehr erfahren</a>
       </div>
       <div class="product-card">
         <img src="images/fes-ex-system.png" alt="FES-Ex System">
         <h3>FES-Ex System</h3>
         <p>Innovative Front-Elektro-Startlösungen für Segelflugmodelle.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="fes-ex-system.html" class="btn">Mehr erfahren</a>
       </div>
       <div class="product-card">
         <img src="images/zubehoer.png" alt="Zubehör">
         <h3>Zubehör</h3>
         <p>Passgenaues Zubehör – von Luftschrauben bis Spezialkabeln.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="zubehoer.html" class="btn">Mehr erfahren</a>
       </div>
       <div class="product-card">
         <img src="images/entwicklung.png" alt="Entwicklung">
         <h3>Entwicklung</h3>
         <p>Maßgeschneiderte Entwicklungsdienstleistungen für Antriebssysteme.</p>
-        <a href="#" class="btn">Mehr erfahren</a>
+        <a href="entwicklung.html" class="btn">Mehr erfahren</a>
       </div>
     </section>
   </main>

--- a/style.css
+++ b/style.css
@@ -346,3 +346,16 @@ footer a {
   color: var(--orange);
   text-decoration: none;
 }
+
+/* Detailansicht für einzelne Produktseiten */
+.product-detail {
+  max-width: 800px;
+  margin: 2rem auto;
+  text-align: center;
+}
+.product-detail img {
+  width: 100%;
+  max-width: 400px;
+  height: auto;
+  margin-bottom: 1rem;
+}

--- a/zubehoer.html
+++ b/zubehoer.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Torcman – Zubehör</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <a href="index.html">
+      <img src="images/TORCMAN_Logo_90.png" alt="Torcman Logo" class="logo">
+    </a>
+    <nav>
+      <a href="produkte.html">Produkte</a>
+      <a href="index.html#ueber-uns">Über uns</a>
+      <a href="index.html#kontakt">Kontakt</a>
+    </nav>
+  </header>
+  <main>
+    <h1 class="page-title">Zubehör</h1>
+    <section class="product-detail">
+      <img src="images/zubehoer.png" alt="Zubehör">
+      <p>Passgenaues Zubehör – von Luftschrauben bis Spezialkabeln.</p>
+    </section>
+  </main>
+  <footer>
+    &copy; 2025 Torcman GmbH – Alle Rechte vorbehalten.
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add individual category pages with basic content
- link category cards on both the home and products pages to the new pages
- style product detail sections for simple layout

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68404dd7dfb083298637906b1fff046f