### PR TITLE
Align map next to contact info

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,22 +118,24 @@
 
   <section id="kontakt">
     <h2>Kontakt</h2>
-    <address>
-      Torcman GmbH<br>
-      Riedweg 25<br>
-      D-89081 Ulm – Söflingen<br><br>
-      <strong>Telefon:</strong> +49 731 379 905 70<br>
-      <strong>Hotline:</strong> Mo–Fr, 8–12 Uhr<br>
-      <strong>E-Mail:</strong> <a href="mailto:mail@torcman.de">mail@torcman.de</a><br>
-      <strong>Web:</strong> <a href="https://www.torcman.de">www.torcman.de</a>
-    </address>
-    <div class="map-container">
-      <iframe
-        src="https://www.google.com/maps?q=Riedweg%2025%2089081%20Ulm&t=&z=15&ie=UTF8&iwloc=&output=embed"
-        loading="lazy"
-        referrerpolicy="no-referrer-when-downgrade"
-        allowfullscreen>
-      </iframe>
+    <div class="contact-layout">
+      <address>
+        Torcman GmbH<br>
+        Riedweg 25<br>
+        D-89081 Ulm – Söflingen<br><br>
+        <strong>Telefon:</strong> +49 731 379 905 70<br>
+        <strong>Hotline:</strong> Mo–Fr, 8–12 Uhr<br>
+        <strong>E-Mail:</strong> <a href="mailto:mail@torcman.de">mail@torcman.de</a><br>
+        <strong>Web:</strong> <a href="https://www.torcman.de">www.torcman.de</a>
+      </address>
+      <div class="map-container">
+        <iframe
+          src="https://www.google.com/maps?q=Riedweg%2025%2089081%20Ulm&t=&z=15&ie=UTF8&iwloc=&output=embed"
+          loading="lazy"
+          referrerpolicy="no-referrer-when-downgrade"
+          allowfullscreen>
+        </iframe>
+      </div>
     </div>
   </section>
 

--- a/style.css
+++ b/style.css
@@ -325,15 +325,28 @@ section h2 {
 #kontakt address {
   font-style: normal;
   line-height: 1.6;
+  flex: 1 1 300px;
+}
+#kontakt .contact-layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-start;
 }
 #kontakt .map-container {
   margin-top: 1rem;
   border: 1px solid var(--lightgrey);
+  flex: 1 1 300px;
 }
 #kontakt iframe {
   width: 100%;
   height: 300px;
   border: 0;
+}
+@media (min-width: 700px) {
+  #kontakt .map-container {
+    margin-top: 0;
+  }
 }
 footer {
   background: var(--darkgrey);


### PR DESCRIPTION
## Summary
- place contact info and map in a flex container
- style new `.contact-layout` so the map sits next to the address

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68404e2144b08329b98c6fb153a44e56