### PR TITLE
Center ueber torcman section

### DIFF
--- a/style.css
+++ b/style.css
@@ -309,7 +309,7 @@ section h2 {
 /* 7. Über uns */
 #ueber-uns {
   max-width: 800px;
-  margin: auto 0 4rem;
+  margin: 0 auto 4rem;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- adjust margin on `#ueber-uns` so the "Über Torcman" section is centered

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405157bd288329854e1ec4c9343ef8