### PR TITLE
Fix image paths from markdown

### DIFF
--- a/loadContent.js
+++ b/loadContent.js
@@ -7,7 +7,9 @@ function loadMarkdown() {
   fetch(`content/${file}.md`)
     .then(r => r.text())
     .then(md => {
-      placeholder.innerHTML = marked.parse(md);
+      let html = marked.parse(md);
+      html = html.replace(/\.\.\/images\//g, 'images/');
+      placeholder.innerHTML = html;
       if (window.initSlideshow) window.initSlideshow();
       if (window.initCarousel) window.initCarousel();
     })


### PR DESCRIPTION
## Summary
- fix images paths by rewriting '../images' to 'images' when loading markdown

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684164662ac48329b4a15972c67ccd6e