### PR TITLE
Fix image paths

### DIFF
--- a/loadContent.js
+++ b/loadContent.js
@@ -7,9 +7,7 @@ function loadMarkdown() {
   fetch(`content/${file}.md`)
     .then(r => r.text())
     .then(md => {
-      let html = marked.parse(md);
-      html = html.replace(/\.\.\/images\//g, 'images/');
-      placeholder.innerHTML = html;
+      placeholder.innerHTML = marked.parse(md);
       if (window.initSlideshow) window.initSlideshow();
       if (window.initCarousel) window.initCarousel();
     })


### PR DESCRIPTION
## Summary
- revert path replacement in loadContent.js so image paths from markdown remain unchanged

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684165d472288329a2f71eedc006f5b4