### PR TITLE
Fix image path handling

### DIFF
--- a/loadContent.js
+++ b/loadContent.js
@@ -7,7 +7,9 @@ function loadMarkdown() {
   fetch(`content/${file}.md`)
     .then(r => r.text())
     .then(md => {
-      placeholder.innerHTML = marked.parse(md);
+      let html = marked.parse(md);
+      html = html.replace(/\.\.\/images\//g, 'images/');
+      placeholder.innerHTML = html;
       if (window.initSlideshow) window.initSlideshow();
       if (window.initCarousel) window.initCarousel();
     })


### PR DESCRIPTION
## Summary
- replace `../images/` path fragments in markdown when injecting HTML

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684168b29a048329a5a500a7abd81e90