### PR TITLE
Restore images in markdown pages

### DIFF
--- a/content/antriebe.md
+++ b/content/antriebe.md
@@ -1,5 +1,6 @@
 <h1 class="page-title">Antriebe</h1>
 <section class="product-detail">
+  <img src="../images/antriebe.png" alt="Antriebe">
   <p>Leistungsstarke Außenläufer-Motoren für höchste Effizienz und Zuverlässigkeit.</p>
 </section>
 <section class="text-content">

--- a/content/entwicklung.md
+++ b/content/entwicklung.md
@@ -1,5 +1,6 @@
 <h1 class="page-title">Entwicklung</h1>
 <section class="product-detail">
+  <img src="../images/entwicklung.png" alt="Entwicklung">
   <h2>Deine Idee. Unsere Lösung. – Entwicklungskompetenz für Modell und Industrie</h2>
   <p>Ob Maßanfertigung für den Wettbewerbspiloten oder Sonderentwicklung für industrielle Anwendungen: Torcman entwickelt, was nicht von der Stange kommt. Unsere Stärke liegt im Verständnis komplexer Anforderungen – und der Fähigkeit, sie effizient in technische Lösungen zu übersetzen. Von der ersten Machbarkeitsanalyse über CAD-Entwürfe, Simulationen und Prototypen bis hin zur Serienfertigung in kleinen Stückzahlen bieten wir den kompletten Entwicklungszyklus.</p>
   <p>Dabei profitieren unsere Partner von kurzen Wegen, tiefem Anwendungsverständnis und der einzigartigen Kombination aus Modellflug-Know-how und industrieller Denkweise. Unsere Motoren kommen zum Einsatz in Schleifmaschinen, Drohnen, Generatoren, Forschungseinrichtungen und überall dort, wo maximale Effizienz auf minimalem Bauraum gefragt ist.</p>

--- a/content/fahrwerke.md
+++ b/content/fahrwerke.md
@@ -1,5 +1,6 @@
 <h1 class="page-title">Fahrwerke</h1>
 <section class="product-detail">
+  <img src="../images/fahrwerke.png" alt="Fahrwerke">
   <h2>Sicher landen, sauber starten – Elektrische Fahrwerke mit System</h2>
   <p>
     Ein Fahrwerk entscheidet maßgeblich über sauberes Rollen, sichere Starts und weiche Landungen – und beeinflusst wesentlich Optik und Gewicht eines jeden Flugmodells. Bei Torcman setzen wir auf elektrische Einziehfahrwerke, die speziell für Großsegler und anspruchsvolle Scale-Modelle konzipiert sind.

--- a/content/fes-ex-system.md
+++ b/content/fes-ex-system.md
@@ -1,5 +1,6 @@
 <h1 class="page-title">FES-Ex System</h1>
 <section class="product-detail">
+  <img src="../images/fes-ex-system.png" alt="FES-Ex System">
   <p>Innovative Front-Elektro-Startlösungen für Segelflugmodelle.</p>
   <p><strong>Innovation trifft Eleganz – Das klappbare Einziehtriebwerk für Großsegler</strong></p>
   <p>Mit dem FES-Ex System revolutioniert Torcman den elektrischen Eigenstart: Statt klassischer Faltpropeller, die im Luftstrom klappen, fährt der Propeller samt Antrieb kompakt in den Rumpf ein – und verschwindet nahezu vollständig im aerodynamischen Profil. Die Vorteile liegen auf der Hand: maximale Leistung im Steigflug, minimaler Luftwiderstand im Gleitflug und eine Integration, die sich optisch wie technisch perfekt ins Modell einfügt.</p>

--- a/content/home.md
+++ b/content/home.md
@@ -1,5 +1,8 @@
 <section class="hero slideshow">
   <div class="slides">
+    <img src="../images/slide1.png" class="slide active" alt="">
+    <img src="../images/slide2.png" class="slide" alt="">
+    <img src="../images/slide3.png" class="slide" alt="">
   </div>
   <div class="hero-content">
     <h1>Effizienz. Präzision. Leistung.</h1>
@@ -15,51 +18,61 @@
   <button class="carousel-btn prev" aria-label="Zurück">‹</button>
   <div class="carousel-track">
     <div class="product-card">
+      <img src="../images/antriebe.png" alt="Antriebe">
       <h3>Antriebe</h3>
       <p>Leistungsstarke Außenläufer-Motoren für höchste Effizienz.</p>
       <a href="antriebe.html" class="btn">Mehr erfahren</a>
     </div>
     <div class="product-card">
+      <img src="../images/fahrwerke.png" alt="Fahrwerke">
       <h3>Fahrwerke</h3>
       <p>Präzise gefertigte Einziehfahrwerke für elegante Starts.</p>
       <a href="fahrwerke.html" class="btn">Mehr erfahren</a>
     </div>
     <div class="product-card">
+      <img src="../images/fes-ex-system.png" alt="FES-Ex System">
       <h3>FES-Ex System</h3>
       <p>Innovative Front-Elektro-Startlösungen für Segelflugmodelle.</p>
       <a href="fes-ex-system.html" class="btn">Mehr erfahren</a>
     </div>
     <div class="product-card">
+      <img src="../images/zubehoer.png" alt="Zubehör">
       <h3>Zubehör</h3>
       <p>Passgenaues Zubehör – von Luftschrauben bis Spezialkabeln.</p>
       <a href="zubehoer.html" class="btn">Mehr erfahren</a>
     </div>
     <div class="product-card">
+      <img src="../images/entwicklung.png" alt="Entwicklung">
       <h3>Entwicklung</h3>
       <p>Maßgeschneiderte Entwicklungsdienstleistungen für Antriebssysteme.</p>
       <a href="entwicklung.html" class="btn">Mehr erfahren</a>
     </div>
     <div class="product-card">
+      <img src="../images/antriebe.png" alt="Antriebe">
       <h3>Antriebe</h3>
       <p>Leistungsstarke Außenläufer-Motoren für höchste Effizienz.</p>
       <a href="antriebe.html" class="btn">Mehr erfahren</a>
     </div>
     <div class="product-card">
+      <img src="../images/fahrwerke.png" alt="Fahrwerke">
       <h3>Fahrwerke</h3>
       <p>Präzise gefertigte Einziehfahrwerke für elegante Starts.</p>
       <a href="fahrwerke.html" class="btn">Mehr erfahren</a>
     </div>
     <div class="product-card">
+      <img src="../images/fes-ex-system.png" alt="FES-Ex System">
       <h3>FES-Ex System</h3>
       <p>Innovative Front-Elektro-Startlösungen für Segelflugmodelle.</p>
       <a href="fes-ex-system.html" class="btn">Mehr erfahren</a>
     </div>
     <div class="product-card">
+      <img src="../images/zubehoer.png" alt="Zubehör">
       <h3>Zubehör</h3>
       <p>Passgenaues Zubehör – von Luftschrauben bis Spezialkabeln.</p>
       <a href="zubehoer.html" class="btn">Mehr erfahren</a>
     </div>
     <div class="product-card">
+      <img src="../images/entwicklung.png" alt="Entwicklung">
       <h3>Entwicklung</h3>
       <p>Maßgeschneiderte Entwicklungsdienstleistungen für Antriebssysteme.</p>
       <a href="entwicklung.html" class="btn">Mehr erfahren</a>

--- a/content/produkte.md
+++ b/content/produkte.md
@@ -1,26 +1,31 @@
 <h1 class="page-title">Produkte</h1>
 <section class="product-grid">
   <div class="product-card">
+    <img src="../images/antriebe.png" alt="Antriebe">
     <h3>Antriebe</h3>
     <p>Leistungsstarke Außenläufer-Motoren für höchste Effizienz.</p>
     <a href="antriebe.html" class="btn">Mehr erfahren</a>
   </div>
   <div class="product-card">
+    <img src="../images/fahrwerke.png" alt="Fahrwerke">
     <h3>Fahrwerke</h3>
     <p>Präzise gefertigte Einziehfahrwerke für elegante Starts.</p>
     <a href="fahrwerke.html" class="btn">Mehr erfahren</a>
   </div>
   <div class="product-card">
+    <img src="../images/fes-ex-system.png" alt="FES-Ex System">
     <h3>FES-Ex System</h3>
     <p>Innovative Front-Elektro-Startlösungen für Segelflugmodelle.</p>
     <a href="fes-ex-system.html" class="btn">Mehr erfahren</a>
   </div>
   <div class="product-card">
+    <img src="../images/zubehoer.png" alt="Zubehör">
     <h3>Zubehör</h3>
     <p>Passgenaues Zubehör – von Luftschrauben bis Spezialkabeln.</p>
     <a href="zubehoer.html" class="btn">Mehr erfahren</a>
   </div>
   <div class="product-card">
+    <img src="../images/entwicklung.png" alt="Entwicklung">
     <h3>Entwicklung</h3>
     <p>Maßgeschneiderte Entwicklungsdienstleistungen für Antriebssysteme.</p>
     <a href="entwicklung.html" class="btn">Mehr erfahren</a>

--- a/content/zubehoer.md
+++ b/content/zubehoer.md
@@ -1,5 +1,6 @@
 <h1 class="page-title">Zubehör</h1>
 <section class="product-detail">
+  <img src="../images/zubehoer.png" alt="Zubehör">
   <p>Passgenaues Zubehör – von Luftschrauben bis Spezialkabeln.</p>
 </section>
 <section>


### PR DESCRIPTION
## Summary
- re-add slide and product images to `home.md`
- restore product detail images across markdown pages

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684186fa1c248329b58e58f431d7a24c